### PR TITLE
Dockerised.

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -31,9 +31,14 @@ USER appuser
 # Copy the built binary from the 'builder' stage
 COPY --from=builder /pandora-backend .
 
+COPY .env .env
+COPY *.mmdb .
+
 # Expose port 80 for the honeypot and 8080 for the website
 EXPOSE 80
 EXPOSE 8080
+
+ENV GIN_MODE=release
 
 # Command to run the executable
 CMD ["./pandora-backend"]

--- a/backend/stats.go
+++ b/backend/stats.go
@@ -319,7 +319,7 @@ func startStats(wg *sync.WaitGroup) {
 		log.Println("Warning: Error loading .env file, continuing with environment variables.")
 	}
 	googleAiAPIKey = os.Getenv("GEMINI_API_KEY")
-	prompt = os.Getenv("GEMINI_PROMPT") // Corrected env var name?
+	prompt = os.Getenv("GEMINI_PROMPT")
 
 	// Initialize the Google Gemini AI client
 	geminiClient = initGemini()
@@ -335,16 +335,22 @@ func startStats(wg *sync.WaitGroup) {
 		tagCounts[tag] = 0
 	}
 
-	// --- Initialization is complete ---
+	// Initialization is complete
 	log.Println("Stats service initialization finished.")
 	// Signal to the main function that it can proceed.
 	wg.Done()
 
 	// Set up the Gin router
 	router := gin.Default()
-	router.Use(cors.Default())
+	router.Use(cors.New(cors.Config{
+		AllowOrigins:     []string{"*"},
+		AllowMethods:     []string{"GET"},
+		AllowHeaders:     []string{"Origin", "Content-Type", "Accept", "Authorization"},
+		ExposeHeaders:    []string{"Content-Length"},
+		AllowCredentials: true,
+		MaxAge:           12 * time.Hour,
+	}))
 
-	// API endpoints
 	router.GET("/uptime", getUptime)
 	router.GET("/average-response-time", getAverageResponseTime)
 	router.GET("/last-ten-requests", getLastTenRequests)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   backend:
     container_name: backend
@@ -8,36 +6,58 @@ services:
       dockerfile: Dockerfile
     ports:
       - "80:80" # Port that the HoneyPot listens to and responds on.
-    #   - "8080:8080" # Port the HoneyPot stats servers runs on
-    volumes:
-      - ./backend/GeoLite2-City.mmdb:/app/GeoLite2-City.mmdb:ro
-    networks:
-      - pandorasbox-net
+      - "8080:8080" # Stats server API port
     restart: always
     environment:
       TZ: Australia/Brisbane
+      LLM_URL: "http://llm-cpuonly:5000" # Change this to the service name you've picked
+    networks:
+      - pandorasbox-net
 
-  llm:
-    container_name: llm
+  # llm-cuda:
+  #   container_name: llm-cuda
+  #   build:
+  #     context: ./llm/model
+  #     dockerfile: Dockerfile.nvd
+  #   networks:
+  #     - pandorasbox-net
+  #   deploy:
+  #     resources:
+  #       reservations:
+  #         devices:
+  #           - driver: nvidia
+  #             count: all
+  #             capabilities: [gpu]
+  #   environment:
+  #     TZ: Australia/Brisbane
+  #   restart: always
+
+  llm-cpuonly:
+    container_name: llm-cpuonly
     build:
       context: ./llm/model
-      dockerfile: DockerfileNVD
-    # ports:
-    #   - "5000:5000" # Port that the backend connects to the LLM by
-    volumes:
-      - ./llm/model:/app
+      dockerfile: Dockerfile.cpu
     networks:
       - pandorasbox-net
-    deploy: # Enable this for Nvidia
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
     environment:
       TZ: Australia/Brisbane
     restart: always
+
+  # llm-rocm:
+  #   container_name: llm-rocm
+  #   build:
+  #     context: ./llm/model
+  #     dockerfile: Dockerfile.amd
+  #   environment:
+  #     TZ: Australia/Brisbane
+  #   restart: always
+  #   devices:
+  #     - /dev/kfd
+  #     - /dev/dri
+  #   group_add:
+  #     - video
+  #   networks:
+  #     - pandorasbox-net
 
   website:
     container_name: website
@@ -48,10 +68,7 @@ services:
       - "3000:3000" # Dashboard port
     depends_on:
       - backend
-    networks:
-      - pandorasbox-net
     environment:
-      NEXT_PUBLIC_BACKEND_URL: http://backend:8080
       TZ: Australia/Brisbane
     restart: always
 

--- a/llm/model/Dockerfile.amd
+++ b/llm/model/Dockerfile.amd
@@ -1,0 +1,24 @@
+# Use an official PyTorch image with CUDA support
+FROM rocm/pytorch:latest
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container at /app
+COPY requirements_docker.txt .
+
+# Install any needed packages specified in requirements_docker.txt
+RUN pip install --no-cache-dir -r requirements_docker.txt
+
+# Copy the rest of the application
+COPY . .
+
+# Make port 5000 available to the world outside this container
+EXPOSE 5000
+
+# Give execute permissions to the script
+RUN chmod +rx use_model_flask.py
+
+# Run the command to start the flask server
+CMD ["python3", "use_model_flask.py"]
+

--- a/llm/model/Dockerfile.cpu
+++ b/llm/model/Dockerfile.cpu
@@ -1,0 +1,29 @@
+# Use an official PyTorch image with CUDA support
+FROM python:3.12-slim
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy the requirements file into the container at /app
+COPY requirements_docker.txt .
+
+# Install any needed packages specified in requirements_docker.txt
+RUN pip install --no-cache-dir -r requirements_docker.txt
+
+RUN pip install --no-cache-dir \
+  --extra-index-url https://download.pytorch.org/whl/cpu \
+  torch \
+  torchvision \
+  torchaudio 
+
+# Copy the rest of the application
+COPY . .
+
+# Make port 5000 available to the world outside this container
+EXPOSE 5000
+
+# Give execute permissions to the script
+RUN chmod +rx use_model_flask.py
+
+# Run the command to start the flask server
+CMD ["python3", "use_model_flask.py"]

--- a/llm/model/Dockerfile.nvd
+++ b/llm/model/Dockerfile.nvd
@@ -5,11 +5,10 @@ FROM pytorch/pytorch:2.7.1-cuda12.6-cudnn9-runtime
 WORKDIR /app
 
 # Copy the requirements file into the container at /app
-COPY requirements.txt .
+COPY requirements_docker.txt .
 
-# Install any needed packages specified in requirements.txt
-# Using pip from the PyTorch environment
-RUN pip install --no-cache-dir -r requirements.txt
+# Install any needed packages specified in requirements_docker.txt
+RUN pip install --no-cache-dir -r requirements_docker.txt
 
 # Copy the rest of the application
 COPY . .
@@ -17,9 +16,9 @@ COPY . .
 # Make port 5000 available to the world outside this container
 EXPOSE 5000
 
-# Define environment variable
-ENV FLASK_APP=use_model_flask.py
+# Give execute permissions to the script
+RUN chmod +rx use_model_flask.py
 
 # Run the command to start the flask server
-CMD ["flask", "run", "--host=0.0.0.0"]
+CMD ["python3", "use_model_flask.py"]
 

--- a/llm/model/requirements.txt
+++ b/llm/model/requirements.txt
@@ -1,4 +1,9 @@
-flask
+--extra-index-url https://download.pytorch.org/whl/cu128
+torch
+torchvision
+torchaudio
+accelerate>=0.26.0
 transformers
 datasets
 scikit-learn
+flask

--- a/llm/model/requirements_docker.txt
+++ b/llm/model/requirements_docker.txt
@@ -1,0 +1,5 @@
+accelerate>=0.26.0
+transformers
+datasets
+scikit-learn
+flask

--- a/llm/model/use_model_flask.py
+++ b/llm/model/use_model_flask.py
@@ -147,4 +147,4 @@ def get_response():
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(host="0.0.0.0")


### PR DESCRIPTION
Project can now be run easily with:
`sudo docker compose up -d`

This will build and launch all components of the project, visit `http://localhost:3000` to view the dashboard. Requests are received by the honeypot on port 80.

In the docker-compose.yaml ensure you pick the right llm container for your machine, cpuonly is default but there are Nvidia and AMD containers to use as well (for hardware acceleration).